### PR TITLE
remove tool catalog table

### DIFF
--- a/overview/tool_catalog.md
+++ b/overview/tool_catalog.md
@@ -4,29 +4,6 @@ order: 997
 
 # HTAN Tool Catalog
 
-For the most current listing of available tools, [please see the portal.](https://humantumoratlas.org/tools)
+The HTAN Network consists of ten research centers and two pilot projects. The results from each project have been built using an array of computational tools, now collected into a catalog which is available on the portal. These tools are sure to be compatible with HTAN data!
 
-The HTAN Network consists of ten research centers, and two pilot projects. The results from each project have been built using an array of computational tools, now collected into a catalog which is available on the portal. These tools are sure to be compatible with HTAN data!
-
-
-| Name                     |  Atlas          |  Type              |  Assay                   |  Publication      |  Homepage                                                 |
-|--------------------------|-----------------|--------------------|--------------------------|-------------------|-----------------------------------------------------------|
-| cBioPortal               |  N/A            |  Web application   |  Bulk DNA, Bulk RNA-seq  |  PMID: 22588877   |  https://cbioportal.org                                   |
-| ISB-CGC Google BigQuery  |  N/A            |  Database          |  scRNA-seq, Imaging      |                   |  https://isb-cgc.appspot.com/    |
-| ISB-CGC Google BigQuery Notebooks |  N/A   |  Notebook          |  scRNA-seq, Imaging      |                   |  https://isb-cancer-genomics-cloud.readthedocs.io/en/latest/sections/HTANNotebooks.html  |
-| Minerva                  |  HTAN HMS       |  Suite             |  Imaging                 |  PMID: 33768192   |  https://www.cycif.org/software/minerva                   |
-| Single Cell Toolkit      |  HTAN BU        |  Suite             |  scRNA-seq               |  PMID: 35354805   |  http://camplab.net/sctk                                  |
-| CellXGene                |  N/A            |  Web application   |  scRNA-seq               |                   |  https://cellxgene.cziscience.com/                        |
-| MCMICRO                  |  HTAN HMS       |  Suite             |  Imaging                 |  PMID: 34824477   |  https://mcmicro.org/                                     |
-| Mask R-CNN               |  HTAN MSK       |  Notebook          |  CODEX                   |                   |  https://github.com/dpeerlab/MaskRCNN_cell                |
-| cancer.usegalaxy.org     |  N/A            |  Suite             |  Omics, Imaging          |                   |  https://cancer.usegalaxy.org/                            |
-| scATAC-pro               |  HTAN Stanford  |  Library, CLI tool |  scATAC-seq              |  PMID: 32312293   |  https://github.com/tanlabcode/scATAC-pro                 |
-| CytoTalk                 |  HTAN Stanford  |  Library           |  scRNA-seq               |  PMID: 33853780   |  https://github.com/tanlabcode/CytoTalk                   |
-| SINBAD                   |  HTAN Stanford  |  Library           |  scmC-seq                |                   |  https://github.com/tanlabcode/SINBAD.0.1                 |
-| SCRABBLE                 |  HTAN Stanford  |  Library           |  scRNA-seq, Bulk RNA-seq |  PMID: 33853780   |  https://github.com/tanlabcode/SCRABBLE                   |
-| MAPLE                    |  HTAN Stanford  |  Library           |  scmC-seq                |  PMID: 33219054   |  https://github.com/tanlabcode/MAPLE.1.0                  |
-| BCTMA                    |  HTAN Stanford  |  Script            |  CyCIF                   |                   |  https://gitlab.com/eburling/BCTMA                        |
-| ME-VAE                   |  HTAN OHSU      |  Script            |  CyCIF                   |  PMID: 35322205   |  https://github.com/GelatinFrogs/ME-VAE_Architecture      |
-| SHIFT                    |  HTAN OHSU      |  Library, CLI tool |  H&E, MxIF               |  PMID: 33060677   |  https://gitlab.com/eburling/SHIFT                        |
-| ASHLAR                   |  HTAN HMS       |  Library, CLI tool |  Spatial Proteomics      |  PMID: 35972352   |  https://labsyspharm.github.io/ashlar/                    |
-| SCIMAP                   |  HTAN HMS       |  Library           |  Spatial Proteomics      |  PMID: 35404441   |  https://scimap.xyz/                                      |
+For the most current listing of available tools, [please see the HTAN data portal.](https://humantumoratlas.org/tools)


### PR DESCRIPTION
As discussed on the [July 3rd 2023 coordination call ](https://docs.google.com/document/d/1P-MgHepA_8Wb95UyzVxlyghJKHXj4Gs_oyRfN3o3E_Y/edit), removing the tools catalog table from the missing manual and instead pointing to the tools catalog page of the data portal. 