### PR TITLE
Adding phase 2 liaisons

### DIFF
--- a/data_submission/Data_Liaisons.md
+++ b/data_submission/Data_Liaisons.md
@@ -8,18 +8,19 @@ Upon joining HTAN, Centers are assigned a data liaison from the DCC.  Trans-Netw
 
 ## Phase 2 Liaisons
 
-| Atlas | Academic Center | Atlas ID | Liaison | Email |
+| Atlas | Lead Institution | Atlas ID | Liaison | Email |
 |-------|-----------------|----------|---------|-------|
-| HTAN2_Gastric_PCA | MD Anderson | pending | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
-| HTAN2_Glioma_PCA | CalTech | pending | Ino de Bruijn | debruiji@mskcc.org |
-| HTAN2_Myeloma_PCA | DFCI | pending | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
-| HTAN2_Pancreas_PCA | OHSU  | pending | Adam Taylor | adam.taylor@sagebase.org |
-| HTAN2_Skin_PCA | UCSF | pending | Adam Taylor | adam.taylor@sagebase.org |
-| HTAN2_Colorectal_HTA | Vanderbilt | pending | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
-| HTAN2_Lymphoma_HTA | Yale | pending | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
-| HTAN2_Ovary_HTA | MD Anderson | pending | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
-| HTAN2_Pediatric_HTA | USC/CHLA | pending | Ino de Bruijn | debruiji@mskcc.org |
-| HTAN2_Prostate_HTA | WUSTL | pending | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+| HTAN2_Skin_PCA | UCSF | HTA200 | Adam Taylor | adam.taylor@sagebase.org |
+| HTAN2_Pancreas_PCA | OHSU  | HTA201 | Adam Taylor | adam.taylor@sagebase.org |
+| HTAN2_Glioma_PCA | CalTech | HTA202 | Ino de Bruijn | debruiji@mskcc.org |
+| HTAN2_Gastric_PCA | MD Anderson | HTA203 | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
+| HTAN2_Myeloma_PCA | DFCI | HTA204 | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
+| HTAN2_Pediatric_HTA | USC/CHLA | HTA205 | Ino de Bruijn | debruiji@mskcc.org |
+| HTAN2_Prostate_HTA | WUSTL | HTA206 | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+| HTAN2_Colorectal_HTA | Vanderbilt | HTA207 | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+| HTAN2_Ovary_HTA | MD Anderson | HTA208 | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
+| HTAN2_Lymphoma_HTA | Yale | HTA209 | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+
 
 ## Phase 1 Liaisons
 

--- a/data_submission/Data_Liaisons.md
+++ b/data_submission/Data_Liaisons.md
@@ -6,7 +6,22 @@ order: 997
 
 Upon joining HTAN, Centers are assigned a data liaison from the DCC.  Trans-Network Projects (TNPs) are also assigned liaisons. The DCC liaisons assist each of the research centers in successfully uploading data and metadata files.  
 
-Here is the current list of centers, their atlases and DCC liaisons:
+## Phase 2 Liaisons
+
+| Atlas | Academic Center | Atlas ID | Liaison | Email |
+|-------|-----------------|----------|---------|-------|
+| HTAN2_Gastric_PCA | MD Anderson | pending | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
+| HTAN2_Glioma_PCA | CalTech | pending | Ino de Bruijn | debruiji@mskcc.org |
+| HTAN2_Myeloma_PCA | DFCI | pending | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
+| HTAN2_Pancreas_PCA | OHSU  | pending | Adam Taylor | adam.taylor@sagebase.org |
+| HTAN2_Skin_PCA | UCSF | pending | Adam Taylor | adam.taylor@sagebase.org |
+| HTAN2_Colorectal_HTA | Vanderbilt | pending | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+| HTAN2_Lymphoma_HTA | Yale | pending | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+| HTAN2_Ovary_HTA | MD Anderson | pending | Jennifer Altreuter | jennifer@ds.dfci.harvard.edu |
+| HTAN2_Pediatric_HTA | USC/CHLA | pending | Ino de Bruijn | debruiji@mskcc.org |
+| HTAN2_Prostate_HTA | WUSTL | pending | Dar'ya Pozhidayeva | dpozhida@systemsbiology.org |
+
+## Phase 1 Liaisons
 
 | Atlas | Atlas ID | Liaison | Email |
 |-------|----------|---------|-------|

--- a/data_submission/Data_Liaisons.md
+++ b/data_submission/Data_Liaisons.md
@@ -8,7 +8,7 @@ Upon joining HTAN, Centers are assigned a data liaison from the DCC.  Trans-Netw
 
 ## Phase 2 Liaisons
 
-| Atlas | Lead Institution | Atlas ID | Liaison | Email |
+| Atlas | Awardee Organization | Atlas ID | Liaison | Email |
 |-------|-----------------|----------|---------|-------|
 | HTAN2_Skin_PCA | UCSF | HTA200 | Adam Taylor | adam.taylor@sagebase.org |
 | HTAN2_Pancreas_PCA | OHSU  | HTA201 | Adam Taylor | adam.taylor@sagebase.org |

--- a/data_submission/specific_details.md
+++ b/data_submission/specific_details.md
@@ -14,6 +14,8 @@ Please see [Data Standards](https://data.humantumoratlas.org/standards) for an o
 
 [Imaging](https://docs.google.com/document/d/1iNicigsSytekEQLkmeNJd2NOJ9VTKzBDfYj3BmvGcro/edit#heading=h.b6j67xcu50c2)
 
+[Mass Spectrometry](https://docs.google.com/document/d/1uW51P7b4Gl5PYnwbLKxbqjR5JEQ_J1yXyqaWCfsCTS8/edit?usp=sharing)
+
 [RPPA](https://docs.google.com/document/d/1UznHRELT6TlPa7vtgCKKeDZ1jeAhAhdRjuBRmzu-Oss/edit?usp=sharing)
 
 [Sequencing Data](https://docs.google.com/document/d/1543YyAW_CwkrKFVzvS9Xwl_dpmruCzK6fA4sIRrZcLQ/edit?usp=sharing)

--- a/overview/centers.md
+++ b/overview/centers.md
@@ -6,6 +6,22 @@ order: 999
 
 HTAN currently consists of ten research centers, and two pilot projects. There are also multiple trans-network projects, referred to as TNPs. Each research center or TNP Project is identified with a unique HTAN prefix.
 
+## Phase 2 Centers
+| Prefix | Contact Institution or Project Name     | Atlas Type       | Area of Focus                     |
+| ------ | --------------------------------------- | ---------------- | --------------------------------- |
+| HTA200 | University of California San Francisco | Pre-Cancer Atlas | Skin Cancer |
+| HTA201 | Oregon Health & Science University (OHSU) | Pre-Cancer Atlas | Pancreatic Cancer |
+| HTA202 | California Institute of Technology (CalTech) |	Pre-Cancer Atlas | Low Grade Glioma |
+| HTA203 | MD Anderson (MDA)| Pre-Cancer Atlas | Gastric Cancer |
+| HTA204 | Dana-Farber Cancer Institute (DFCI) | Pre-Cancer Atlas | Myeloma |
+| HTA205 | Children's Hosptital of Los Angeles | Tumor Atlas | Pediatric Cancers |
+| HTA206 | Washington University in St. Louis | Tumor Atlas | Prostate Cancer |
+| HTA207 | Vanderbilt University | Tumor Atlas | Colorectal Cancer |
+| HTA208 | MD Anderson (MDA) | Tumor Atlas | Ovarian Cancer |
+| HTA209 | Yale University | Tumor Atlas | Lymphoma |
+
+## Phase 1 Centers
+
 | Prefix | Contact Institution or Project Name     | Atlas Type       | Area of Focus                     |
 | ------ | --------------------------------------- | ---------------- | --------------------------------- |
 | HTA1   | Human Tumor Atlas Pilot Project (HTAPP) | Tumor Atlas      | Pilot Project                     |


### PR DESCRIPTION
Center Atlas IDs currently listed as 'pending' until DCC agrees on prefix assignments. (potentially PCAs first and the HTA last. Ie 20-24 are PCA and 25-29 are HTAs)