### PR TITLE
Link updates

### DIFF
--- a/addtnl_info/RFC.md
+++ b/addtnl_info/RFC.md
@@ -7,15 +7,7 @@ order: 996
 ## RFC Overview
 The HTAN Data Model is expected to evolve with advances in science.  This evolution is a community-driven, peer-reviewed process, where members of a working group will first assess established community data standards and create a request for comment (RFC) document soliciting community feedback.
 
-The status of current RFCs is provided in the [RFC Overview](https://docs.google.com/document/d/1dJ7NUoVCtewdtny8bITwtWnzItB4IibL5kJO3ZNh0go/edit?usp=sharing) document.  The RFC Overview can be used to:
-
-- Get a sense of what is available in DCA.
-- Get a sense of new assays being considered.
-- Look at old RFCs & get a sense of past discussions/considerations.
-
-!!! Note:
-The links to specific RFC documents within the RFC Overview do **not** represent the final data model.  Once an RFC is closed and an assay is available on the Data Curator App (DCA), the metadata template on the DCA represents the final data model.  Details regarding the data model are also available on HTAN's [Data Standards page](https://humantumoratlas.org/standards) and HTAN's [data-models repository](https://github.com/ncihtan/data-models) on github.
-!!!
+Once an RFC is closed and an assay is available on the Data Curator App (DCA), the metadata template on the DCA represents the final data model.  Details regarding the data model are also available on HTAN's [Data Standards page](https://humantumoratlas.org/standards) and HTAN's [data-models repository](https://github.com/ncihtan/data-models) on github.
 
 ## Data Model Changes
 The following are requests which require changes to the Data Model and may result in the initiation of a RFC:

--- a/addtnl_info/data_release.md
+++ b/addtnl_info/data_release.md
@@ -8,5 +8,5 @@ The Data Coordinating Center (DCC) prepares major data releases every 4-6 months
 
 ![The HTAN Data Release Process](../img/Data_release.svg)
 
-Please see [HTAN Data Release Process](https://docs.google.com/document/d/15xvIbfyQmgbMD_uB2e0SwPFw67_AePB5YspF4dsilCA/edit#heading=h.tddsmkcn4p1p) for more information regarding the data release process.
+Please see [HTAN Data Release Process](https://docs.google.com/document/d/10sv22HgtWAKt1wlV9eGbbI-itWejASVqDy42esS43DQ/edit?usp=drive_link) for more information regarding the data release process.
 

--- a/addtnl_info/tnps.md
+++ b/addtnl_info/tnps.md
@@ -7,7 +7,7 @@ Trans-Network Projects are multi-center projects created to facilitate collabora
 
 - **Phase 1 TNPs**: [Synapse HTAN Phase 1 Wiki page](https://www.synapse.org/#!Synapse:syn17022193/wiki/584990). 
 - **Phase 2 TNPs**: [Synapse HTAN Phase 2 Wiki page](https://www.synapse.org/Synapse:syn63296487/wiki/629655). \
-:warning: The Phase 2 wiki pages are new.  Phase 2 Center members will be provided access to this wiki in the near future.
+:warning: The Phase 2 wiki pages are new.  Phase 2 Center members will be provided access to this wiki in the near future.  Currently there are no TNPs associated with Phase 2.
 
 !!! Note
 
@@ -15,7 +15,7 @@ The HTAN Synapse Wiki page is restricted to HTAN members.  Please contact htandc
 !!!
 
 
-Current Trans-Network Projects
+Current Trans-Network Projects (Phase 1)
 
 | Code | Name | Description |
 |------|------|-------------|

--- a/addtnl_info/tnps.md
+++ b/addtnl_info/tnps.md
@@ -3,7 +3,11 @@ order: 995
 ---
 
 # Trans-Network Projects (TNPs)
-Trans-Network Projects are multi-center projects created to facilitate collaborative research.  Examples include cross-testing experimental and analytical protocols, exchange of personnel to disseminate SOPs or pursuit of additional HTAN critical methods or technologies.  Specific information about each TNP is available on [HTAN's Synapse Wiki page](https://www.synapse.org/#!Synapse:syn17022193/wiki/584990) for HTAN members. 
+Trans-Network Projects are multi-center projects created to facilitate collaborative research.  Examples include cross-testing experimental and analytical protocols, exchange of personnel to disseminate SOPs or pursuit of additional HTAN critical methods or technologies.  Specific information about each TNP is available on the Synapse wiki pages for HTAN members. 
+
+- **Phase 1 TNPs**: [Synapse HTAN Phase 1 Wiki page](https://www.synapse.org/#!Synapse:syn17022193/wiki/584990). 
+- **Phase 2 TNPs**: [Synapse HTAN Phase 2 Wiki page](https://www.synapse.org/Synapse:syn63296487/wiki/629655). \
+:warning: The Phase 2 wiki pages are new.  Phase 2 Center members will be provided access to this wiki in the near future.
 
 !!! Note
 

--- a/data_submission/specific_details.md
+++ b/data_submission/specific_details.md
@@ -6,20 +6,20 @@ order: 993
 
 Please see [Data Standards](https://data.humantumoratlas.org/standards) for an overview of HTAN Data Levels and Metadata Attributes for each data type. The following links provide specific submission details for each data type.  
 
-[Accessory Files](https://docs.google.com/document/d/1c7WPfgOpjd8B44LDccuR4quwrVXg3yhGQlbQ6Bp4p7Q/edit?usp=sharing)
+[Accessory Files](https://docs.google.com/document/d/1cHto1lrGGUhFVG-Cf1CShH3xC9_V8Fj3NElMtQyO3fM/edit?usp=drive_link)
 
-[Biospecimen](https://docs.google.com/document/d/1uywrFE7dioO5o6OXRxBrG6HMDM1-eepDN43qEPVLOD0/edit?usp=sharing)
+[Biospecimen](https://docs.google.com/document/d/12w61mgroXH0Q05JrDId2nqHWlC8h_0RcGLb7YwmZo8c/edit?usp=drive_link)
 
-[Clinical Data](https://docs.google.com/document/d/10rNmhdoQLA25dIbK6yEybB0hyeSsV90fRjDtVY3x8M0/edit?usp=sharing)
+[Clinical Data](https://docs.google.com/document/d/112F5VglA-9kdYjN7BSQ5boXYlNyfxZM7d6tfs4egkwE/edit?usp=drive_link)
 
-[Imaging](https://docs.google.com/document/d/1iNicigsSytekEQLkmeNJd2NOJ9VTKzBDfYj3BmvGcro/edit#heading=h.b6j67xcu50c2)
+[Imaging](https://docs.google.com/document/d/1tK24SA9FLmYmqc8JC2C325dqKF-cabyJqsNLQDGtYyU/edit?usp=drive_link)
 
-[Mass Spectrometry](https://docs.google.com/document/d/1uW51P7b4Gl5PYnwbLKxbqjR5JEQ_J1yXyqaWCfsCTS8/edit?usp=sharing)
+[Mass Spectrometry](https://docs.google.com/document/d/1wpiM41iYWa5ZqwLiMiEEaqIjiUVbYXHUNFj43R7Yuh0/edit?usp=drive_link)
 
-[RPPA](https://docs.google.com/document/d/1UznHRELT6TlPa7vtgCKKeDZ1jeAhAhdRjuBRmzu-Oss/edit?usp=sharing)
+[RPPA](https://docs.google.com/document/d/1UDEIeJ6AUdrRX3Dy8upOZ3i3c3CMVGSJ8pozWGNCXEM/edit?usp=drive_link)
 
-[Sequencing Data](https://docs.google.com/document/d/1543YyAW_CwkrKFVzvS9Xwl_dpmruCzK6fA4sIRrZcLQ/edit?usp=sharing)
+[Sequencing Data](https://docs.google.com/document/d/1VMKFZ99ZvZaiftnle1WGu3TxDQX-0HEZ8Aolgo418CQ/edit?usp=drive_link)
 
-[Spatial Transcriptomics](https://docs.google.com/document/d/1oVIG-9wi83IgQj4SKTkKqLfzyXeF54hGRh68PdXPDTg/edit?usp=sharing)
+[Spatial Transcriptomics](https://docs.google.com/document/d/1v6P1AeQJHzKCF3BMhPyqpD393nA45ZRAC1T1dEukJaU/edit?usp=drive_link)
 
 


### PR DESCRIPTION
- updated links to new files in HTAN2
- removed link and language related to RFC Overview
- adds language to TNP page to indicate TNPs are currently phase 1 only and to provide link to wiki2 for the future.