### PR TITLE
CDS to GC name change + info re: protocols

### DIFF
--- a/addtnl_info/tool_protocol.md
+++ b/addtnl_info/tool_protocol.md
@@ -2,8 +2,9 @@
 order: 1000
 ---
 
-# Submitting Tools
+# Submitting Tools and Protocols
 
+## Computational Tools
 Computational tools developed or used to support HTAN research projects can be added to the HTAN tool catalog by filling out the tool curation form available on HTAN's internal Synapse wiki pages:
 
 - **Phase 1 Centers**: [Synapse HTAN Phase 1 Wiki page](https://www.synapse.org/#!Synapse:syn17022193/wiki/584990). 
@@ -14,4 +15,6 @@ Computational tools developed or used to support HTAN research projects can be a
 HTAN Synapse Wiki pages are restricted to HTAN members.  Please contact htandcc@ds.dfci.harvard.edu if you are a member of HTAN and need access to the wiki.
 !!!
 
+## Research Protocols
 
+HTAN Centers are encouraged to document their research protocols in protocols.io. Assay metadata submitted to HTAN requires a Protocols.io ID or DOI link to a free/open protocol resource describing in detail the assay protocol and/or the protocol by which the sample was obtained or generated.

--- a/data_access/cds_cgc.md
+++ b/data_access/cds_cgc.md
@@ -2,11 +2,11 @@
 order: 993
 ---
 
-# Accessing CDS Data in SB-CGC
+# Accessing CRDC Data in SB-CGC
 
-[Seven Bridges Cancer Genomics Cloud (SB-CGC)](https://www.cancergenomicscloud.org/) is a cloud platform for the analysis and storage of large cancer datasets. There are two mechanisms for transferring HTAN data from the NCI's Cancer Data Service (CDS) to SB-CGC:
+[Seven Bridges Cancer Genomics Cloud (SB-CGC)](https://www.cancergenomicscloud.org/) is a cloud platform for the analysis and storage of large cancer datasets. There are two mechanisms for transferring HTAN data from the NCI's Cancer Research Data Commons (CRDC) to SB-CGC:
 
-1. Direct export from the [CDS Portal](https://dataservice.datacommons.cancer.gov/).
+1. Direct export from the CDRC General Commons (GC) [Portal](https://general.datacommons.cancer.gov/#/data).
 2. Export via a Data Repository Service (DRS) Manifest.
 
 !!! Access Requirements
@@ -14,33 +14,28 @@ order: 993
 **Access-controlled data** To download access-controlled files, you must first complete a [dbGAP request](db_gap.md).
 !!!
 
-HTAN Data in CDS includes:
+HTAN Data in CRDC includes:
 1. Open Access Level 2 Imaging Files; and
 2. Access-controlled Sequencing Data (e.g. fastq and BAM files)
 
 ## Imaging Files
 
 ### Direct Export 
-In order to access HTAN imaging data within the [CDS Portal](https://dataservice.datacommons.cancer.gov/), navigate to the portal in a web browser and click on the **Explore CDS Data** button on the landing page.
-
-<p align="center"><img width="364" alt="1" src="https://github.com/ncihtan/htan_missing_manual/assets/123744798/40aff1af-a58f-49dc-9253-6ee5e67ef419">
-</p>
-
-&nbsp;
+In order to access HTAN imaging data within CRDC, navigate to the [GC Portal](https://general.datacommons.cancer.gov/#/data) in a web browser.
 
 On the Data Explorer page, expand the STUDY section on the left sidebar, scroll down, and check the box next to **Human Tumor Atlas (HTAN) imaging data**.
 
-![CDS Portal: Accessing HTAN Imaging Data](../img/cds_img4.png)
+![GC Portal: Accessing HTAN Imaging Data](../img/cds_img4.png)
 
 This action will change the summary panel to reflect selecting HTAN data only.
 
 Scroll down, or click on the **Collapse View** tab on the upper right just below the query summary line in order to see the tabulated view of all of the participants, samples or files in HTAN.
 
-![CDS Portal: Accessing HTAN Imaging Data](../img/cds_img7.png)
+![GC Portal: HTAN Imaging Data, Collapse View](../img/cds_img7.png)
 
 Click on the **Add All Files** button, or select the check boxes next to all Participants, Samples or Files for a subselection and then click on the **Add Selected** button.  This action will update your cart icon in the upper right corner.
 
-![CDS Portal: Accessing HTAN Imaging Data](../img/cds_img5.png)
+![GC Portal: HTAN Imaging Data, Select Files](../img/cds_img5.png)
 
 Clicking on the cart icon, will bring up a list of the selected files. Expand the **Available Export Options** drop down menu and select **Export to Cancer Genomics Cloud**.
 
@@ -48,7 +43,7 @@ Clicking on the cart icon, will bring up a list of the selected files. Expand th
 Note: The **Download Manifest** can also be chosen instead of **Export to Cancer Genomics Cloud**.  Please see [DRS Manifest Files](#drs-manifest-files) for more information.
 !!!
 
-![CDS Portal: Adding Data to Cart](../img/cds_export_button.png)
+![GC Portal: Adding Data to Cart](../img/cds_export_button.png)
 
 Follow the prompts to log in to CGC.  Then select a Destination project, check the box to agree to CGC terms and import the data.
 
@@ -63,19 +58,23 @@ DRS manifests are CSV files which list the files you would like to obtain. They 
 
 For HTAN data, DRS Manifests can be generated from three different locations: 
 
-* CDS Portal
+* General Commons (GC) Portal
 * HTAN Data Portal
 * Google BigQuery
 
-##### Generating a DRS Manifest from the CDS Portal
+##### Generating a DRS Manifest from the GC Portal
 
-Follow the directions for [Direct Export](#direct-export) of files from CDS.  In the cart, click on the **Download Manifest** button on the upper right to download a CSV-formated (Excel compatible) copy of your file list.
+Follow the directions for [Direct Export](#direct-export) of files from GC.  In the cart, click on the **Download Manifest** button on the upper right to download a CSV-formated (Excel compatible) copy of your file list.
 
 ##### Generating a DRS Manifest from the HTAN Data Portal
 
+!!!
+Cancer Data Services (CDS) has changed its name to General Commons (GC). The HTAN Portal will be updated soon to reflect this change.
+!!!
+
 From the [HTAN Data Portal](https://humantumoratlas.org/), click **CDS/SB-CGC (Open Access)** under the **Data Access** filter. 
 
-![HTAN Portal: Accessing Imaging Data in CDS](../img/cds_img1.png)
+![HTAN Portal: Accessing Imaging Data in GC](../img/cds_img1.png)
 
 Navigate to the **Files** tab, check the box next to **Filename** in upper left, and then click **Download selected files**. 
 
@@ -87,7 +86,11 @@ Click **Download Manifest**, which will download a local file called `cds_manife
 
 
 ##### Generating a DRS Manifest from Google BigQuery
-HTAN metadata and a mapping of HTAN Data File IDs to CDS DRS URIs are available as Google BigQuery tables via the Institute for Systems Biology Cancer Gateway in the Cloud (ISB-CGC) (see [Google BigQuery](https://docs.humantumoratlas.org/data_access/biq_query/)). These tables can be used to subset data to a cohort of interest, and obtain DRS URIs of files to access. 
+!!!
+Cancer Data Services (CDS) has changed its name to General Commons (GC). The Big Query notebook referenced below will be updated soon to reflect this change.
+!!!
+
+HTAN metadata and a mapping of HTAN Data File IDs to GC DRS URIs are available as Google BigQuery tables via the Institute for Systems Biology Cancer Gateway in the Cloud (ISB-CGC) (see [Google BigQuery](https://docs.humantumoratlas.org/data_access/biq_query/)). These tables can be used to subset data to a cohort of interest, and obtain DRS URIs of files to access. 
 
 For a step-by-step guide on how to generate a DRS manifest file using Google BigQuery, please see the Python notebook [Creating_CDS_Data_Import_Manifests_Using_BQ.ipynb](https://github.com/isb-cgc/Community-Notebooks/blob/master/HTAN/Python%20Notebooks/Creating_CDS_Data_Import_Manifests_Using_BQ.ipynb).
 
@@ -96,11 +99,11 @@ For a step-by-step guide on how to generate a DRS manifest file using Google Big
 Once you have your manifest, follow the instructions on SB-CGC's [Import from a DRS server](https://docs.cancergenomicscloud.org/docs/import-from-a-drs-server#import-from-a-manifest-file) documentation page to import data from a manifest file.
 
 ## Sequencing Data
-The [CDS Portal](https://dataservice.datacommons.cancer.gov/), within NCI's Cancer Research Data Commons (CRDC), provides an interface to filter and select data from a variety of NCI programs, including controlled-access, primary sequence data from the Human Tumor Atlas Network (HTAN).
+The [General Commons (GC) Portal](https://general.datacommons.cancer.gov/#/data), within NCI's Cancer Research Data Commons (CRDC), provides an interface to filter and select data from a variety of NCI programs, including controlled-access, primary sequence data from the Human Tumor Atlas Network (HTAN).
 
-The directions for accessing sequencing data on CDS are similar to those for [Level 2 Imaging Data Access](#imaging-files), including Direct Export from CDS to CGC and importing data using a Data Repository Service (DRS) Manifest.  Please follow the [Level 2 Imaging Data Access](#imaging-files) directions to access sequencing data, noting the following changes:
+The directions for accessing sequencing data on GC are similar to those for [Level 2 Imaging Data Access](#imaging-files), including Direct Export from GC to CGC and importing data using a Data Repository Service (DRS) Manifest.  Please follow the [Level 2 Imaging Data Access](#imaging-files) directions to access sequencing data, noting the following changes:
 
-1. For Direct Export or Generating a DRS Manifest from CDS, choose **Human Tumor Atlas (HTAN) primary sequence data** on the STUDY section of the left hand sidebar instead of **Human Tumor Atlas (HTAN) imaging data**.
+1. For Direct Export or Generating a DRS Manifest from GC, choose **Human Tumor Atlas (HTAN) primary sequence data** on the STUDY section of the left hand sidebar instead of **Human Tumor Atlas (HTAN) imaging data**.
 
 <p align="center"><img width="891" alt="Figure 3" src="https://github.com/ncihtan/htan_missing_manual/assets/123744798/14e07c72-16d4-463a-b8b2-1ef5f8d72107"></p>
 
@@ -109,4 +112,9 @@ The directions for accessing sequencing data on CDS are similar to those for [Le
 2. To generate a DRS Manifest from the 
 [HTAN Data Portal](https://humantumoratlas.org/), click **CDS/SB-CGC (dbGaP)** under the **Data Access** filter instead of **CDS/SB-CGC (Open Access)**. 
 
-![HTAN Portal: Accessing Genomic Data in CDS](../img/cds_genomics1.png)
+!!!
+Cancer Data Services (CDS) has changed its name to General Commons (GC). The HTAN Portal will be updated soon to reflect this change.
+!!!
+
+![HTAN Portal: Accessing Genomic Data in GC](../img/cds_genomics1.png)
+

--- a/data_access/cds_gen3.md
+++ b/data_access/cds_gen3.md
@@ -31,6 +31,9 @@ HTAN files available through the NCI CRDC Cancer Data Service can be downloaded 
 
 
 ### Step 4: Select Files from the HTAN Data Portal
+!!!
+Cancer Data Services (CDS) has changed its name to General Commons (GC). The HTAN Portal will be updated soon to reflect this change.
+!!!
 
 - Go to the HTAN Data Portal and filter the files based on your criteria (e.g., open access CDS files).
 - Select the files you want to download.

--- a/data_access/introduction.md
+++ b/data_access/introduction.md
@@ -8,10 +8,10 @@ HTAN Data includes both assay files and [metadata](../data_submission/metadata.m
 
 !!! Access Levels
 **open access**: de-identified clinical and biospecimen data, multiplex images, and processed genomic data. Access to this data is mainly provided via [Synapse](https://synapse.org).  \
-**access-controlled**: includes unprocessed genomic data, e.g. fastq and BAM files. Similar to TCGA BAM files, this data is available via [an approved dbGaP mechanism](db_gap.md). Access to this data is controlled by the National Cancer Institute (NCI) Cancer Research Data Commons (CRDC) [Cancer Data Service (CDS)](https://datacommons.cancer.gov/repository/cancer-data-service).
+**access-controlled**: includes unprocessed genomic data, e.g. fastq and BAM files. Similar to TCGA BAM files, this data is available via [an approved dbGaP mechanism](db_gap.md). Access to this data is controlled by the National Cancer Institute (NCI) Cancer Research Data Commons (CRDC) [General Commons (GC)](https://datacommons.cancer.gov/repository/general-commons).
 !!!
 
-The [HTAN Data Portal](https://humantumoratlas.org/explore) provides an overview of all released data and serves as an interface through which all data access can occur. While most data storage and direct data access occurs via Synapse (open access data) and CDS (access-controlled data), HTAN supports many other mechanisms of data access and visualization. These include:
+The [HTAN Data Portal](https://humantumoratlas.org/explore) provides an overview of all released data and serves as an interface through which all data access can occur. While most data storage and direct data access occurs via Synapse (open access data) and GC (access-controlled data), HTAN supports many other mechanisms of data access and visualization. These include:
 
 - [Google BigQuery](biq_query.md) for analysis of metadata and a subset of processed assay data.
 - The [NCI CRDC Imaging Data Commons (IDC)](https://portal.imaging.datacommons.cancer.gov/) for image file visualization and download.

--- a/data_access/portal.md
+++ b/data_access/portal.md
@@ -39,7 +39,7 @@ If you click on any of the Synapse links above, you can immediately download a c
 
 ![HTAN Tabular Data within Excel](../img/portal5.png)
 
-Once you have downloaded metadata files, you can parse them in your favorite programming language, such as R or Python. To understand the individual columns within each metadata file, please refer to the [HTAN Data Model](../../data_model/overview).
+Once you have downloaded metadata files, you can parse them in your favorite programming language, such as R or Python. To understand the individual columns within each metadata file, please refer to the HTAN Data Model [Specific Standards page](../data_model/standards.md).
 
 ## Exploring Available Data
 
@@ -83,6 +83,10 @@ Clicking **View Details** on any of these files will pop open a metadata table. 
 
 ## Downloading Assay Data
 
+!!!
+Cancer Data Services (CDS) has changed its name to General Commons (GC). The HTAN Portal will be updated soon to reflect this change.
+!!!
+
 Once you have specified your filter criteria, the Files tab will display all matching files. At this point, you may see two types of files:
 
 -   Open Access Files (Data Access = Synapse or CDS/SB-CGC (open access)); or
@@ -103,8 +107,8 @@ To download files, select the files you would like, then click on the "Download 
 ![Select Files and Download](../img/HTAN_Portal_Selected_Files.png)
 
 The pop-up window that appears provides the information you need to access the files, including directions for:
-1. accessing [Cancer Data Service (CDS) data on SB-CGC](cds_cgc.md);
-2. directly downloading CDS data using the [Gen3 Client](cds_gen3.md); and
+1. accessing [Cancer Research Data Commons (CRDC) data on SB-CGC](cds_cgc.md);
+2. directly downloading CRDC data using the [Gen3 Client](cds_gen3.md); and
 3. accessing data available on Synapse via either the Synapse web interface or the Synapse CLI. 
 
 ![Download pop-up window](../img/HTAN_Portal_Download.png)

--- a/data_access/synapse_to_cds.md
+++ b/data_access/synapse_to_cds.md
@@ -6,7 +6,7 @@ order: 992
 
 [Seven Bridges Cancer Genomics Cloud (SB-CGC)](https://www.cancergenomicscloud.org/) is a cloud platform for the analysis and storage of large cancer datasets. 
 
-HTAN’s open-access data, including most datasets, is hosted on Synapse and can be loaded into SB-CGC using the following instructions. Note that open-access Level 2 images are available separately through the [Cancer Data Service (CDS)](cds_cgc.md).
+HTAN’s open-access data, including most datasets, is hosted on Synapse and can be loaded into SB-CGC using the following instructions. Note that open-access Level 2 images are available separately through the National Cancer Institutes's [General Commons (GC)](cds_cgc.md).
 
 ## Video walkthrough
 

--- a/readme.md
+++ b/readme.md
@@ -14,6 +14,7 @@ If you have feedback for this manual, including broken links or incorrect inform
 
 | Date       | Comment                  | Changes summary |
 |------------|--------------------------|-----------------|
+| 2025-04-28 |                          | Updates to reflect CDS name change to General Commons (GC)|
 | 2025-03-21 | Fourth version of manual | Rework of Data Access Sections and creation of Data Visualization section |                         
 | 2025-03-10 |                          | Updated Identifier sections to reflect Phase 2 schema |
 | 2025-03-04 |                          | Added gen3 data access instructions |


### PR DESCRIPTION
1. Changed "CDS" to "GC".
2. Added temporary warnings where appropriate to say that HTAN Portal and Google BQ will be changed to reflect the CDS to GC name change soon.
3. added statement encouraging HTAN Centers to use protocols.io.