### PR TITLE
remove link to HTAN1 data release SOP, add info re: licensing

### DIFF
--- a/addtnl_info/data_release.md
+++ b/addtnl_info/data_release.md
@@ -7,6 +7,3 @@ order: 998
 The Data Coordinating Center (DCC) prepares major data releases every 4-6 months. HTAN Centers are notified of the data submission deadline for an upcoming data release. After that deadline, the pre-release process involves a number of data processing and metadata verification steps. Data is released via the HTAN Data Portal, and then disseminated to various Cancer Data Research Commons (CRDC) nodes including Cancer Data Service (CDS) and the Institute for Systems Biology Cancer Gateway in the Cloud (ISB-CGC) to enable download of controlled-access data and long-term cloud access
 
 ![The HTAN Data Release Process](../img/Data_release.svg)
-
-Please see [HTAN Data Release Process](https://docs.google.com/document/d/1xMS3au9uFk5IHmcn99KbrZN1lp3AXjCTFJ7kWLeP1MQ/edit?usp=sharing) for more information regarding the data release process.
-

--- a/addtnl_info/governance.md
+++ b/addtnl_info/governance.md
@@ -22,6 +22,9 @@ Examples of incidents that should be reported include:
 
 Reports submitted through the Help Desk will be addressed by the Privacy, Security & Compliance Office, who will coordinate the appropriate response process.
 
+## Licensing
+Please see HTAN's [External Data Sharing Policy](https://drive.google.com/file/d/17vN_8zcWsPNBtnLe1mOr35wqhUbuMaWI/view) for information regarding data licensing and sharing. HTAN Imaging Data has a CC-BY 4.0 license.
+
 ## Policy Documents
 
 - [HTAN Internal Data and Materials Sharing Agreement (DMSA) v1.1](https://drive.google.com/file/d/186TMLs3L2dKrXvMQLGuEYC-7jyGHCRw3/view?usp=drive_link)

--- a/data_access/citing_HTAN.md
+++ b/data_access/citing_HTAN.md
@@ -11,3 +11,5 @@ Rozenblatt-Rosen et al. The Human Tumor Atlas Network: Charting Tumor Transition
 de Bruijn, I., Nikolov, M., Lau, C. et al. Sharing data from the Human Tumor Atlas Network through standards, infrastructure and community engagement. Nat Methods (2025). Nat Methods: https://doi.org/10.1038/s41592-025-02643-0
 
 Remember also to cite any relevant HTAN dataset-specific publications, which can be found listed on the portal's [Explore page](https://humantumoratlas.org/explore) under the Publications tab.
+
+Information regarding data sharing and data licensing can be found on the [Governance and Policy page](../addtnl_info/governance.md)


### PR DESCRIPTION
1. Removed out of data link to phase 1 data release SOP.
2. Added information about data licensing -- see JIRA HTAN-754.
